### PR TITLE
docker-compose with j2 with user and password. Some minor changes wit…

### DIFF
--- a/inventory/host_vars/showyourheart-test.devs.coop/config.yml
+++ b/inventory/host_vars/showyourheart-test.devs.coop/config.yml
@@ -37,4 +37,4 @@ backups_role_enabled: False
 postgresql_python_library: python3-psycopg2
 
 security_enabled: False
-firewall_enabled: False
+firewall_enabled: True

--- a/inventory/host_vars/showyourheart-test.devs.coop/expose_bi.yml
+++ b/inventory/host_vars/showyourheart-test.devs.coop/expose_bi.yml
@@ -1,8 +1,8 @@
 bi_db_user: bi
 bi_db_migration_user: migration
 
-bi_db_password: 123456
-bi_db_migration_password: 123456
+bi_db_password: AA123456
+bi_db_migration_password: AA123456
 
 expose_db_port: 5432
 bi_ip: 78.46.187.140

--- a/inventory/host_vars/showyourheart.local/django_config.yml
+++ b/inventory/host_vars/showyourheart.local/django_config.yml
@@ -1,0 +1,17 @@
+django_debug_var: True
+django_secret_key: adsñfañlkdsfjadsñlkfjañlkfjañlkdsfjqoiwjfañiwoc
+
+# Branch to deploy
+django_project_version: develop
+
+# Postmark SMTP configuration
+django_email_host_user: aaa
+django_email_host_password: bbb
+
+#Default test users
+django_user_admin_email: test@test.com
+django_user_admin_password: A123456
+django_superuser_email: supertest@test.com
+django_superuser_password: A123456
+django_user_gov_admin_email: govtest@test.com
+django_user_gov_admin_password: A123456

--- a/roles/django/tasks/main.yml
+++ b/roles/django/tasks/main.yml
@@ -42,6 +42,14 @@
     group: "{{ django_group_name }}"
     dest: "{{ django_user_home_dir }}ShowYourHeart/docker/init-user-db.sh"
 
+- name: Render template for the docker-compose file
+  template:
+    src: docker-compose.yml.j2
+    owner: "{{ django_user_name }}"
+    group: "{{ django_group_name }}"
+    dest: "{{ django_user_home_dir }}ShowYourHeart/docker/docker-compose.yml"
+
+
 - name: Render template for the .env file
   template:
     src: env.j2

--- a/roles/django/templates/docker-compose.yml.j2
+++ b/roles/django/templates/docker-compose.yml.j2
@@ -1,0 +1,43 @@
+version: "3.5"
+
+networks:
+  showyourheart-network:
+    name: showyourheart-network
+
+services:
+  showyourheart-app:
+    restart: on-failure
+    container_name: showyourheart-app
+    build:
+      context: ..
+      dockerfile: ./docker/Dockerfile
+      target: development
+    env_file: ./.env
+    ports:
+      - "127.0.0.1:1601:8000"
+    volumes:
+      - ../src:/srv
+    depends_on:
+      - showyourheart-db
+    networks:
+      - showyourheart-network
+
+  showyourheart-db:
+    container_name: showyourheart-db
+    image: postgres:14
+    environment:
+      POSTGRES_USER: "{{ db_user }}"
+      POSTGRES_PASSWORD: "{{ db_password }}"
+    ports:
+      - "0.0.0.0:5432:5432"
+    volumes:
+      - ../dumps:/dumps
+      - ./init-user-db.sh:/docker-entrypoint-initdb.d/init-user-db.sh
+    networks:
+      - showyourheart-network
+
+  showyourheart-selenium:
+    container_name: showyourheart-selenium
+    image: selenium/standalone-chrome:4.16.0
+    networks:
+      - showyourheart-network

--- a/roles/django/templates/init-user-db.sh.j2
+++ b/roles/django/templates/init-user-db.sh.j2
@@ -2,7 +2,6 @@
 set -e
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
-	CREATE USER {{ db_user }};
 	CREATE DATABASE {{ db_name }};
 	GRANT ALL PRIVILEGES ON DATABASE {{ db_name }} TO {{ db_user}};
 EOSQL

--- a/roles/expose-postgresql/tasks/main.yml
+++ b/roles/expose-postgresql/tasks/main.yml
@@ -1,4 +1,24 @@
 ---
+
+- name: Ensure apt cache is up to date
+  become: true
+  become_user: root
+  apt:
+    update_cache: yes
+    cache_valid_time: "{{ 48 * 60 * 60 }}"  # consider the cache to be valid within 48 hours
+
+
+- name: Install the packages postgresql-client & python3-psycopg2
+  become: true
+  become_user: root
+  apt:
+    pkg:
+      - postgresql-client
+      - python3-psycopg2
+    state: present
+
+
+
 - name: Create users to access the DB
   postgresql_user:
     login_host: "localhost"
@@ -9,7 +29,7 @@
     name: "{{ item.name }}"
     password: "{{ item.password }}"
   loop: "{{ expose_postgresql_users }}"
-  no_log: True
+  no_log: false
   when: expose_postgresql_users is defined
 
 - name: GRANT privs for DB user
@@ -23,6 +43,6 @@
     objs: "{{ item.objs }}"
     privs: "{{ item.privs }}"
   loop: "{{ expose_postgresql_users }}"
-  no_log: True
+  no_log: false
   when: expose_postgresql_users is defined
 


### PR DESCRIPTION
Docker-compose in j2 format. Informed fields:
      POSTGRES_USER: "{{ db_user }}"
      POSTGRES_PASSWORD: "{{ db_password }}"
It deletes the POSTGRES_HOST_AUTH_METHOD=trust for better security.

Installation of postgresql-client and python3-psycopg2 for postgres user permissions.

Enabled firewall.      
